### PR TITLE
Tests pass, but take a second longer. 

### DIFF
--- a/src/UmbracoFileSystemProviders.Azure.Tests/AzureBlobFileSystemTestsBase.cs
+++ b/src/UmbracoFileSystemProviders.Azure.Tests/AzureBlobFileSystemTestsBase.cs
@@ -8,6 +8,8 @@
 // </summary>
 // --------------------------------------------------------------------------------------------------------------------
 
+using System.Threading;
+
 namespace Our.Umbraco.FileSystemProviders.Azure.Tests
 {
     using System;
@@ -418,6 +420,8 @@ namespace Our.Umbraco.FileSystemProviders.Azure.Tests
 
             // Assert
             Assert.AreNotEqual(original, DateTimeOffset.MinValue);
+
+            Thread.Sleep(TimeSpan.FromSeconds(1.1));
 
             // Act
             provider.AddFile("1010/media.jpg", Stream.Null);


### PR DESCRIPTION
Integrated modified date test depend on system clock and has a second granularity

Otherwise looks quite nice. I'll restrain myself from nitpicking about method length and test naming. ;)