### PR TITLE
Fix issue where files do not get deleted after emptying recycle bin

### DIFF
--- a/src/UmbracoFileSystemProviders.Azure.Tests/AzureBlobFileSystemTestsBase.cs
+++ b/src/UmbracoFileSystemProviders.Azure.Tests/AzureBlobFileSystemTestsBase.cs
@@ -468,9 +468,30 @@ namespace Our.Umbraco.FileSystemProviders.Azure.Tests
 
             // Assert
             Assert.IsTrue(provider.DirectoryExists("media/1010/"));
+            Assert.IsTrue(provider.FileExists("media/1010/media.jpg"));
 
             // Act
             provider.DeleteDirectory("media/1010/");
+
+            // Assert
+            Assert.IsFalse(provider.DirectoryExists("media/1010/"));
+            Assert.IsFalse(provider.FileExists("media/1010/media.jpg"));
+        }
+
+        [Test]
+        public void TestDeleteDirectoryRelative()
+        {
+            // Arrange
+            AzureBlobFileSystem provider = this.CreateAzureBlobFileSystem();
+
+            // Act
+            provider.AddFile("media/1010/media.jpg", Stream.Null);
+
+            // Assert
+            Assert.IsTrue(provider.DirectoryExists("media/1010"));
+
+            // Act
+            provider.DeleteDirectory("\\media\\1010");
 
             // Assert
             Assert.IsFalse(provider.DirectoryExists("media/1010/"));

--- a/src/UmbracoFileSystemProviders.Azure/AzureFileSystem.cs
+++ b/src/UmbracoFileSystemProviders.Azure/AzureFileSystem.cs
@@ -245,6 +245,8 @@ namespace Our.Umbraco.FileSystemProviders.Azure
         /// </param>
         public void DeleteDirectory(string path, bool recursive)
         {
+            path = this.FixPath(path);
+
             if (!this.DirectoryExists(path))
             {
                 return;


### PR DESCRIPTION
Hi!  I noticed that after emptying the Media Recycle Bin, the files from those media items still existed on my blob and were accessible from the web.  When using the default file system provider, the files are deleted from disk when the Recycle Bin is empty.

It looks like it was just a mixup with the path.  `DeleteDirectory` was receiving `\\media\\205276` as the path, and `DirectoryExists` was returning `false` for that and never tries to delete the items.  Running the path through `this.FixPath()` seems to fix the issue.

Does this seem like the correct fix?  I tried placing this in a couple other areas to make it more global but did not have much luck.

This was in Umbraco 7.3.0