### PR TITLE
Fix exception updating CreatedDate when file exists

### DIFF
--- a/src/UmbracoFileSystemProviders.Azure/AzureFileSystem.cs
+++ b/src/UmbracoFileSystemProviders.Azure/AzureFileSystem.cs
@@ -216,7 +216,14 @@ namespace Our.Umbraco.FileSystemProviders.Azure
                 }
 
                 // Store the creation date in meta data.
-                blockBlob.Metadata.Add("CreatedDate", created.ToString(CultureInfo.InvariantCulture));
+                if (blockBlob.Metadata.ContainsKey("CreatedDate"))
+                {
+                    blockBlob.Metadata["CreatedDate"] = created.ToString(CultureInfo.InvariantCulture);
+                }
+                else
+                {
+                    blockBlob.Metadata.Add("CreatedDate", created.ToString(CultureInfo.InvariantCulture));
+                }
                 blockBlob.SetMetadata();
             }
             catch (Exception ex)


### PR DESCRIPTION
When a call to `AddFile` is made for an existing file, [this line](https://github.com/JimBobSquarePants/UmbracoFileSystemProviders.Azure/blob/develop/src/UmbracoFileSystemProviders.Azure/AzureFileSystem.cs#L219) causes an exception:

```c#
    blockBlob.Metadata.Add("CreatedDate", created.ToString(CultureInfo.InvariantCulture));
```

...because `CreatedDate` was already added [here](https://github.com/JimBobSquarePants/UmbracoFileSystemProviders.Azure/blob/develop/src/UmbracoFileSystemProviders.Azure/AzureFileSystem.cs#L197).

This adds a quick check to update if it's already there and add if not.

I'm having a trouble writing a test for this as I'm not sure what to test for.  The exception happens after the file has been persisted, so checks for `FileExists` passing just fine.  The only missing code is setting the `CreatedDate` the second time (which shouldn't change anyway, hence it's test passing) and `SetMetaData()`.  I suspect the `TestGetLastModified` test is passing because `LastModified` is in the `Properties` collection which gets [committed before](https://github.com/JimBobSquarePants/UmbracoFileSystemProviders.Azure/blob/develop/src/UmbracoFileSystemProviders.Azure/AzureFileSystem.cs#L211) the exception occurs.  Since there is a `try/catch` I can't test for an exception either :smile:.  Open to any advice, or maybe it's fine the way it is since it really only surfaces during debugging ;)