### PR TITLE
Added configuration sourcing through web.config

### DIFF
--- a/src/UmbracoFileSystemProviders.Azure/AzureBlobFileSystem.cs
+++ b/src/UmbracoFileSystemProviders.Azure/AzureBlobFileSystem.cs
@@ -12,12 +12,32 @@ namespace Our.Umbraco.FileSystemProviders.Azure
     using System.IO;
 
     using global::Umbraco.Core.IO;
-
+    using System.Configuration;
     /// <summary>
     /// The azure file system.
     /// </summary>
     public class AzureBlobFileSystem : IFileSystem
     {
+        /// <summary>
+        /// The configuration key for disabling the virtual path provider.
+        /// </summary>
+        private const string ConnectionStringKey = Constants.Configuration.ConnectionStringKey;
+
+        /// <summary>
+        /// The configuration key for disabling the virtual path provider.
+        /// </summary>
+        private const string ContainerNameKey = Constants.Configuration.ContainerNameKey;
+
+        /// <summary>
+        /// The configuration key for disabling the virtual path provider.
+        /// </summary>
+        private const string RootUrlKey = Constants.Configuration.RootUrlKey;
+
+        /// <summary>
+        /// The configuration key for disabling the virtual path provider.
+        /// </summary>
+        private const string MaxDaysKey = Constants.Configuration.MaxDaysKey;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="AzureBlobFileSystem"/> class.
         /// </summary>
@@ -39,6 +59,45 @@ namespace Our.Umbraco.FileSystemProviders.Azure
         public AzureBlobFileSystem(string containerName, string rootUrl, string connectionString, string maxDays)
         {
             this.FileSystem = AzureFileSystem.GetInstance(containerName, rootUrl, connectionString, maxDays);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AzureBlobFileSystem"/> class from values in web.config through ConfigurationManager.
+        /// </summary>
+        public AzureBlobFileSystem()
+        {
+
+            string connectionString = ConfigurationManager.AppSettings[ConnectionStringKey] as string;
+            if (!string.IsNullOrWhiteSpace(connectionString))
+            {
+                string rootUrl = ConfigurationManager.AppSettings[RootUrlKey] as string;
+                if (string.IsNullOrWhiteSpace(rootUrl))
+                {
+                    throw new InvalidOperationException("Azure Storage Root URL is not defined in web.config. The " + RootUrlKey + " property was not defined or is empty.");
+                }
+
+                string containerName = ConfigurationManager.AppSettings[ContainerNameKey] as string;
+
+                if (string.IsNullOrWhiteSpace(containerName))
+                {
+                    containerName = "media";
+                }
+
+                string maxDays = ConfigurationManager.AppSettings[MaxDaysKey] as string;
+
+                if (string.IsNullOrWhiteSpace(maxDays))
+                {
+                    maxDays = "365";
+                }
+
+                this.FileSystem = AzureFileSystem.GetInstance(containerName, rootUrl, connectionString, maxDays);
+            }
+            else
+            {
+                throw new InvalidOperationException("Unable to retreive the Azure Storage configuration from web.config. " + ConnectionStringKey + " was not defined or is empty.");
+            }
+
+
         }
 
         /// <summary>

--- a/src/UmbracoFileSystemProviders.Azure/Constants.cs
+++ b/src/UmbracoFileSystemProviders.Azure/Constants.cs
@@ -29,6 +29,26 @@ namespace Our.Umbraco.FileSystemProviders.Azure
             /// The configuration key for enabling the storage emulator.
             /// </summary>
             public const string UseStorageEmulatorKey = "AzureBlobFileSystem.UseStorageEmulator";
+
+            /// <summary>
+            /// The configuration key for providing the connection string via the web.config
+            /// </summary>
+            public const string ConnectionStringKey = "AzureBlobFileSystem.ConnectionString";
+
+            /// <summary>
+            /// The configuration key for providing the Azure Blob Container Name via the web.config
+            /// </summary>
+            public const string ContainerNameKey = "AzureBlobFileSystem.ContainerName";
+
+            /// <summary>
+            /// The configuration key for providing the Storage Root URL via the web.config
+            /// </summary>
+            public const string RootUrlKey = "AzureBlobFileSystem.RootUrl";
+
+            /// <summary>
+            /// The configuration key for providing the Maximum Days Cache value via the web.config
+            /// </summary>
+            public const string MaxDaysKey = "AzureBlobFileSystem.MaxDays";
         }
     }
 }


### PR DESCRIPTION
I have added sourcing the configuration through the web.config, this is useful for Azure Websites so you can put the configuration in the portal, rather than check the credentials into source control as part of the FileSystemProviders.config.

When no parameters are specified under the <Provider> node in FileSystemProviders.config, then the values are loaded from web.config.