### PR TITLE
Revert "Added Cdn & fixed tests accordingly"

### DIFF
--- a/src/UmbracoFileSystemProviders.Azure.Installer/InstallerController.cs
+++ b/src/UmbracoFileSystemProviders.Azure.Installer/InstallerController.cs
@@ -65,7 +65,6 @@ namespace Our.Umbraco.FileSystemProviders.Azure.Installer
             var connection = parameters.SingleOrDefault(k => k.Key == "connectionString").Value;
             var containerName = parameters.SingleOrDefault(k => k.Key == "containerName").Value;
             var rootUrl = parameters.SingleOrDefault(k => k.Key == "rootUrl").Value;
-            var cdnUrl = parameters.SingleOrDefault(k => k.Key == "cdnUrl").Value;
 
             if (!TestAzureCredentials(connection, containerName))
             {

--- a/src/UmbracoFileSystemProviders.Azure.Installer/Properties/VersionInfo.cs
+++ b/src/UmbracoFileSystemProviders.Azure.Installer/Properties/VersionInfo.cs
@@ -14,7 +14,7 @@ using System.Reflection;
 //
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
-// [assembly: AssemblyVersion("0.5.2.1")]
-[assembly: AssemblyVersion("0.5.2.1")]
-[assembly: AssemblyFileVersion("0.5.2.1")]
-[assembly: AssemblyInformationalVersion("0.5.2-alpha")]
+// [assembly: AssemblyVersion("0.5.0.10")]
+[assembly: AssemblyVersion("0.5.0.0")]
+[assembly: AssemblyFileVersion("0.5.0.0")]
+[assembly: AssemblyInformationalVersion("0.5.0")]

--- a/src/UmbracoFileSystemProviders.Azure.Tests/FileSystemProviders.config.install.xdt
+++ b/src/UmbracoFileSystemProviders.Azure.Tests/FileSystemProviders.config.install.xdt
@@ -8,7 +8,7 @@
   </Provider>
 
   <Provider alias="media" type="Our.Umbraco.FileSystemProviders.Azure.AzureBlobFileSystem, Our.Umbraco.FileSystemProviders.Azure" xdt:Locator="Match(type)" xdt:Transform="InsertIfMissing">
-    <Parameters xdt:Transform="InsertIfMissing">
+      <Parameters xdt:Transform="InsertIfMissing">
       <add key="containerName" value="media" xdt:Locator="Match(key)" xdt:Transform="InsertIfMissing" />
       <add key="rootUrl" value="http://[myAccountName].blob.core.windows.net/" xdt:Locator="Match(key)" xdt:Transform="InsertIfMissing" />
       <add key="connectionString" value="DefaultEndpointsProtocol=https;AccountName=[myAccountName];AccountKey=[myAccountKey]" xdt:Locator="Match(key)" xdt:Transform="InsertIfMissing" />
@@ -17,7 +17,6 @@
         Defaults to 365 days.
       -->
       <add key="maxDays" value="365" xdt:Locator="Match(key)" xdt:Transform="InsertIfMissing" />
-      <add key="cdnUrl" value="[myCDN].azureedge.net" xdt:Locator="Match(key)" xdt:Transform="InsertIfMissing" />
     </Parameters>
   </Provider>
   <!--

--- a/src/UmbracoFileSystemProviders.Azure.Tests/FileSystemProviders.upgrade.config
+++ b/src/UmbracoFileSystemProviders.Azure.Tests/FileSystemProviders.upgrade.config
@@ -13,7 +13,6 @@
         Defaults to 365 days.
       -->
   		<add key="maxDays" value="365"/>
-      <add key="cdnUrl" value="[myCDN].azureedge.net" />
   	</Parameters>
   </Provider>
    

--- a/src/UmbracoFileSystemProviders.Azure.Tests/InstallerTests.cs
+++ b/src/UmbracoFileSystemProviders.Azure.Tests/InstallerTests.cs
@@ -25,7 +25,7 @@ namespace Our.Umbraco.FileSystemProviders.Azure.Tests
         public void CheckXdtNumberOfParameters()
         {
             var parameters = InstallerController.GetParametersFromXml("FileSystemProviders.config.install.xdt");
-            Assert.AreEqual(5, parameters.Count());
+            Assert.AreEqual(4, parameters.Count());
         }
 
         [Test]

--- a/src/UmbracoFileSystemProviders.Azure.Tests/UmbracoFileSystemProviders.Azure.Tests.csproj
+++ b/src/UmbracoFileSystemProviders.Azure.Tests/UmbracoFileSystemProviders.Azure.Tests.csproj
@@ -276,9 +276,6 @@
     <Analyzer Include="..\packages\StyleCop.Analyzers.1.0.0-beta014\analyzers\dotnet\cs\Newtonsoft.Json.dll" />
     <Analyzer Include="..\packages\StyleCop.Analyzers.1.0.0-beta014\analyzers\dotnet\cs\StyleCop.Analyzers.dll" />
   </ItemGroup>
-  <ItemGroup>
-    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
-  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\packages\StyleCop.Analyzers.1.0.0-beta014\build\StyleCop.Analyzers.targets" Condition="Exists('..\packages\StyleCop.Analyzers.1.0.0-beta014\build\StyleCop.Analyzers.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/src/UmbracoFileSystemProviders.Azure/AzureBlobFileSystem.cs
+++ b/src/UmbracoFileSystemProviders.Azure/AzureBlobFileSystem.cs
@@ -24,8 +24,8 @@ namespace Our.Umbraco.FileSystemProviders.Azure
         /// <param name="containerName">The container name.</param>
         /// <param name="rootUrl">The root url.</param>
         /// <param name="connectionString">The connection string.</param>
-        public AzureBlobFileSystem(string containerName, string rootUrl, string connectionString)
-            : this(containerName, rootUrl, connectionString, "365", string.Empty)
+        public AzureBlobFileSystem(string containerName, string rootUrl, string connectionString) :
+            this(containerName, rootUrl, connectionString, "365")
         {
         }
 
@@ -37,21 +37,8 @@ namespace Our.Umbraco.FileSystemProviders.Azure
         /// <param name="connectionString">The connection string.</param>
         /// <param name="maxDays">The maximum number of days to cache blob items for in the browser.</param>
         public AzureBlobFileSystem(string containerName, string rootUrl, string connectionString, string maxDays)
-            : this(containerName, rootUrl, connectionString, maxDays, string.Empty)
         {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="AzureBlobFileSystem"/> class.
-        /// </summary>
-        /// <param name="containerName">The container name.</param>
-        /// <param name="rootUrl">The root url.</param>
-        /// <param name="connectionString">The connection string.</param>
-        /// <param name="maxDays">The maximum number of days to cache blob items for in the browser.</param>
-        /// <param name="cdnUrl">Url to the CDN on which you wish to expose the ressource</param>
-        public AzureBlobFileSystem(string containerName, string rootUrl, string connectionString, string maxDays, string cdnUrl)
-        {
-            this.FileSystem = AzureFileSystem.GetInstance(containerName, rootUrl, connectionString, maxDays, cdnUrl);
+            this.FileSystem = AzureFileSystem.GetInstance(containerName, rootUrl, connectionString, maxDays);
         }
 
         /// <summary>

--- a/src/UmbracoFileSystemProviders.Azure/AzureFileSystem.cs
+++ b/src/UmbracoFileSystemProviders.Azure/AzureFileSystem.cs
@@ -63,11 +63,6 @@ namespace Our.Umbraco.FileSystemProviders.Azure
         private readonly string rootUrl;
 
         /// <summary>
-        /// The url of the CDN
-        /// </summary>
-        private readonly string cdnUrl;
-
-        /// <summary>
         /// The cloud media blob container.
         /// </summary>
         private readonly CloudBlobContainer cloudBlobContainer;
@@ -82,7 +77,7 @@ namespace Our.Umbraco.FileSystemProviders.Azure
         /// <exception cref="ArgumentNullException">
         /// Thrown if <paramref name="containerName"/> is null or whitespace.
         /// </exception>
-        private AzureFileSystem(string containerName, string rootUrl, string connectionString, int maxDays, string cdnUrl)
+        private AzureFileSystem(string containerName, string rootUrl, string connectionString, int maxDays)
         {
             if (string.IsNullOrWhiteSpace(containerName))
             {
@@ -116,19 +111,10 @@ namespace Our.Umbraco.FileSystemProviders.Azure
                 rootUrl = rootUrl.Trim() + "/";
             }
 
-            if (!string.IsNullOrEmpty(cdnUrl))
-            {
-                if (!cdnUrl.Trim().EndsWith("/"))
-                {
-                    cdnUrl = cdnUrl.Trim() + "/";
-                }
-
-                this.cdnUrl = cdnUrl + containerName + "/";
-            }
-
             this.rootUrl = rootUrl + containerName + "/";
             this.ContainerName = containerName;
             this.MaxDays = maxDays;
+
             this.LogHelper = new WrappedLogHelper();
             this.MimeTypeResolver = new MimeTypeResolver();
         }
@@ -160,9 +146,8 @@ namespace Our.Umbraco.FileSystemProviders.Azure
         /// <param name="rootUrl">The root url.</param>
         /// <param name="connectionString">The connection string.</param>
         /// <param name="maxDays">The maximum number of days to cache blob items for in the browser.</param>
-        /// <param name="cdnUrl">Url to the CDN</param>
         /// <returns>The <see cref="AzureFileSystem"/></returns>
-        public static AzureFileSystem GetInstance(string containerName, string rootUrl, string connectionString, string maxDays, string cdnUrl)
+        public static AzureFileSystem GetInstance(string containerName, string rootUrl, string connectionString, string maxDays)
         {
             lock (Locker)
             {
@@ -174,7 +159,7 @@ namespace Our.Umbraco.FileSystemProviders.Azure
                         max = 365;
                     }
 
-                    fileSystem = new AzureFileSystem(containerName, rootUrl, connectionString, max, cdnUrl);
+                    fileSystem = new AzureFileSystem(containerName, rootUrl, connectionString, max);
                 }
 
                 return fileSystem;
@@ -571,16 +556,7 @@ namespace Our.Umbraco.FileSystemProviders.Azure
         private string ResolveUrl(string path, bool relative)
         {
             // First create the full url
-            Uri url;
-
-            if (!string.IsNullOrEmpty(this.cdnUrl))
-            {
-                url = new Uri(new Uri(this.cdnUrl, UriKind.Absolute), this.FixPath(path));
-            }
-            else
-            {
-                url = new Uri(new Uri(this.rootUrl, UriKind.Absolute), this.FixPath(path));
-            }
+            Uri url = new Uri(new Uri(this.rootUrl, UriKind.Absolute), this.FixPath(path));
 
             if (!relative)
             {

--- a/src/UmbracoFileSystemProviders.Azure/Properties/VersionInfo.cs
+++ b/src/UmbracoFileSystemProviders.Azure/Properties/VersionInfo.cs
@@ -14,7 +14,7 @@ using System.Reflection;
 //
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
-// [assembly: AssemblyVersion("0.5.2.1")]
-[assembly: AssemblyVersion("0.5.2.1")]
-[assembly: AssemblyFileVersion("0.5.2.1")]
-[assembly: AssemblyInformationalVersion("0.5.2-alpha")]
+// [assembly: AssemblyVersion("0.5.0.10")]
+[assembly: AssemblyVersion("0.5.0.0")]
+[assembly: AssemblyFileVersion("0.5.0.0")]
+[assembly: AssemblyInformationalVersion("0.5.0")]


### PR DESCRIPTION
Reverts JimBobSquarePants/UmbracoFileSystemProviders.Azure#33

I need a further look at the pull request as I'm not convinced the installer code is correct. 

E.g. 

    var cdnUrl = parameters.SingleOrDefault(k => k.Key == "cdnUrl").Value;

on line 68 in `InstallerController.cs` is not used.