### PR TITLE
Simplification of the configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,48 +48,34 @@ Update `~/Config/FileSystemProviders.config` replacing the default provider with
 ```xml
 <?xml version="1.0"?>
 <FileSystemProviders>
-  <Provider alias="media" type="Our.Umbraco.FileSystemProviders.Azure.AzureBlobFileSystem, Our.Umbraco.FileSystemProviders.Azure">
-    <Parameters>
-      <add key="containerName" value="media" />
-      <add key="rootUrl" value="http://[myAccountName].blob.core.windows.net/" />
-      <add key="connectionString" value="DefaultEndpointsProtocol=https;AccountName=[myAccountName];AccountKey=[myAccountKey]"/>
-      <!--
-        Optional configuration value determining the maximum number of days to cache items in the browser.
-        Defaults to 365 days.
-      -->
-      <add key="maxDays" value="365" />
-    </Parameters>
-  </Provider>
+  <Provider alias="media" type="Our.Umbraco.FileSystemProviders.Azure.AzureBlobFileSystem, Our.Umbraco.FileSystemProviders.Azure" />
 </FileSystemProviders>
+```
+
+And set the connection string and other configuration properties in the appsettings in the `web.config`.
+
+```xml
+<configuration>
+  <appSettings>
+    <!--Disables the built in Virtual Path Provider which allows for relative paths-->
+    <add key="AzureBlobFileSystem.DisableVirtualPathProvider" value="true" />
+	<add key="AzureBlobFileSystem.ConnectionString" value="DefaultEndpointsProtocol=https;AccountName=[myAccountName];AccountKey=[myAccountKey]" />
+	<add key="AzureBlobFileSystem.ContainerName" value="media" />
+	<add key="AzureBlobFileSystem.MaxDays" value="365" />
+  </appSettings>
+</configuration>
 ```
 
 Developmental mode configuration using the [Azure Storage Emulator](https://azure.microsoft.com/en-us/documentation/articles/storage-use-emulator/) for testing is as follows:
 
 ```xml
-<?xml version="1.0"?>
-<FileSystemProviders>
-  <Provider alias="media" type="Our.Umbraco.FileSystemProviders.Azure.AzureBlobFileSystem, Our.Umbraco.FileSystemProviders.Azure">
-    <Parameters>
-      <add key="containerName" value="media" />
-      <add key="rootUrl" value="http://127.0.0.1:10000/devstoreaccount1/" />
-      <add key="connectionString" value="UseDevelopmentStorage=true"/>
-    </Parameters>
-  </Provider>
-</FileSystemProviders>
-```
-
-Additionally the provider can be further configured with the following application setting in the `web.config`.
-
-```xml
-<?xml version="1.0"?>
 <configuration>
   <appSettings>
     <!--Disables the built in Virtual Path Provider which allows for relative paths-->
     <add key="AzureBlobFileSystem.DisableVirtualPathProvider" value="true" />
-    <!--
-      Enables the development mode for testing. Addition changes to the FileSystemProviders.config are also required
-    -->
-    <add key="AzureBlobFileSystem.UseStorageEmulator" value="true" />
+	<add key="AzureBlobFileSystem.ConnectionString" value="UseDevelopmentStorage=true" />
+	<add key="AzureBlobFileSystem.ContainerName" value="media" />
+	<add key="AzureBlobFileSystem.MaxDays" value="365" />
   </appSettings>
 </configuration>
 ```

--- a/src/UmbracoFileSystemProviders.Azure.Installer/InstallerController.cs
+++ b/src/UmbracoFileSystemProviders.Azure.Installer/InstallerController.cs
@@ -341,12 +341,15 @@ namespace Our.Umbraco.FileSystemProviders.Azure.Installer
 
         private static bool TestAzureCredentials(string connectionString, string containerName)
         {
-            var useEmulator = ConfigurationManager.AppSettings[Azure.Constants.Configuration.UseStorageEmulatorKey] != null
-                               && ConfigurationManager.AppSettings[Azure.Constants.Configuration.UseStorageEmulatorKey]
-                                                      .Equals("true", StringComparison.InvariantCultureIgnoreCase);
+            bool useDevelopmentStorage = false;
+            if (connectionString.Trim().Equals("UseDevelopmentStorage=true", StringComparison.InvariantCultureIgnoreCase))
+            {
+                useDevelopmentStorage = true;
+            }
+
             try
             {
-                var cloudStorageAccount = useEmulator ? CloudStorageAccount.DevelopmentStorageAccount : CloudStorageAccount.Parse(connectionString);
+                var cloudStorageAccount = useDevelopmentStorage ? CloudStorageAccount.DevelopmentStorageAccount : CloudStorageAccount.Parse(connectionString);
 
                 var cloudBlobClient = cloudStorageAccount.CreateCloudBlobClient();
                 var blobContainer = cloudBlobClient.GetContainerReference(containerName);

--- a/src/UmbracoFileSystemProviders.Azure.Tests/AzureBlobFileSystemTestsBase.cs
+++ b/src/UmbracoFileSystemProviders.Azure.Tests/AzureBlobFileSystemTestsBase.cs
@@ -38,14 +38,13 @@ namespace Our.Umbraco.FileSystemProviders.Azure.Tests
         public AzureBlobFileSystem CreateAzureBlobFileSystem(bool disableVirtualPathProvider = false)
         {
             string containerName = "media";
-            string rootUrl = "http://127.0.0.1:10000/devstoreaccount1/";
             string connectionString = "UseDevelopmentStorage=true";
             string maxDays = "30";
 
             Mock<ILogHelper> logHelper = new Mock<ILogHelper>();
             Mock<IMimeTypeResolver> mimeTypeHelper = new Mock<IMimeTypeResolver>();
 
-            return new AzureBlobFileSystem(containerName, rootUrl, connectionString, maxDays)
+            return new AzureBlobFileSystem(containerName, connectionString, maxDays)
             {
                 FileSystem =
                 {

--- a/src/UmbracoFileSystemProviders.Azure.Tests/UmbracoFileSystemProviders.Azure.Tests.csproj
+++ b/src/UmbracoFileSystemProviders.Azure.Tests/UmbracoFileSystemProviders.Azure.Tests.csproj
@@ -276,6 +276,9 @@
     <Analyzer Include="..\packages\StyleCop.Analyzers.1.0.0-beta014\analyzers\dotnet\cs\Newtonsoft.Json.dll" />
     <Analyzer Include="..\packages\StyleCop.Analyzers.1.0.0-beta014\analyzers\dotnet\cs\StyleCop.Analyzers.dll" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\packages\StyleCop.Analyzers.1.0.0-beta014\build\StyleCop.Analyzers.targets" Condition="Exists('..\packages\StyleCop.Analyzers.1.0.0-beta014\build\StyleCop.Analyzers.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/src/UmbracoFileSystemProviders.Azure/AzureBlobFileSystem.cs
+++ b/src/UmbracoFileSystemProviders.Azure/AzureBlobFileSystem.cs
@@ -12,12 +12,32 @@ namespace Our.Umbraco.FileSystemProviders.Azure
     using System.IO;
 
     using global::Umbraco.Core.IO;
-
+    using System.Configuration;
     /// <summary>
     /// The azure file system.
     /// </summary>
     public class AzureBlobFileSystem : IFileSystem
     {
+        /// <summary>
+        /// The configuration key for disabling the virtual path provider.
+        /// </summary>
+        private const string ConnectionStringKey = Constants.Configuration.ConnectionStringKey;
+
+        /// <summary>
+        /// The configuration key for disabling the virtual path provider.
+        /// </summary>
+        private const string ContainerNameKey = Constants.Configuration.ContainerNameKey;
+
+        /// <summary>
+        /// The configuration key for disabling the virtual path provider.
+        /// </summary>
+        private const string RootUrlKey = Constants.Configuration.RootUrlKey;
+
+        /// <summary>
+        /// The configuration key for disabling the virtual path provider.
+        /// </summary>
+        private const string MaxDaysKey = Constants.Configuration.MaxDaysKey;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="AzureBlobFileSystem"/> class.
         /// </summary>
@@ -39,6 +59,45 @@ namespace Our.Umbraco.FileSystemProviders.Azure
         public AzureBlobFileSystem(string containerName, string rootUrl, string connectionString, string maxDays)
         {
             this.FileSystem = AzureFileSystem.GetInstance(containerName, rootUrl, connectionString, maxDays);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AzureBlobFileSystem"/> class from values in web.config through ConfigurationManager.
+        /// </summary>
+        public AzureBlobFileSystem()
+        {
+
+            string connectionString = ConfigurationManager.AppSettings[ConnectionStringKey] as string;
+            if (!string.IsNullOrWhiteSpace(connectionString))
+            {
+                string rootUrl = ConfigurationManager.AppSettings[RootUrlKey] as string;
+                if (string.IsNullOrWhiteSpace(rootUrl))
+                {
+                    throw new InvalidOperationException("Azure Storage Root URL is not defined in web.config. The " + RootUrlKey + " property was not defined or is empty.");
+                }
+
+                string containerName = ConfigurationManager.AppSettings[ContainerNameKey] as string;
+
+                if (string.IsNullOrWhiteSpace(containerName))
+                {
+                    containerName = "media";
+                }
+
+                string maxDays = ConfigurationManager.AppSettings[MaxDaysKey] as string;
+
+                if (string.IsNullOrWhiteSpace(maxDays))
+                {
+                    maxDays = "365";
+                }
+
+                this.FileSystem = AzureFileSystem.GetInstance(containerName, rootUrl, connectionString, maxDays);
+            }
+            else
+            {
+                throw new InvalidOperationException("Unable to retreive the Azure Storage configuration from web.config. " + ConnectionStringKey + " was not defined or is empty.");
+            }
+
+
         }
 
         /// <summary>

--- a/src/UmbracoFileSystemProviders.Azure/Constants.cs
+++ b/src/UmbracoFileSystemProviders.Azure/Constants.cs
@@ -29,6 +29,26 @@ namespace Our.Umbraco.FileSystemProviders.Azure
             /// The configuration key for enabling the storage emulator.
             /// </summary>
             public const string UseStorageEmulatorKey = "AzureBlobFileSystem.UseStorageEmulator";
+
+            /// <summary>
+            /// The configuration key for providing the connection string via the web.config
+            /// </summary>
+            public const string ConnectionStringKey = "AzureBlobFileSystem.ConnectionString";
+
+            /// <summary>
+            /// The configuration key for providing the Azure Blob Container Name via the web.config
+            /// </summary>
+            public const string ContainerNameKey = "AzureBlobFileSystem.ContainerName";
+
+            /// <summary>
+            /// The configuration key for providing the Storage Root URL via the web.config
+            /// </summary>
+            public const string RootUrlKey = "AzureBlobFileSystem.RootUrl";
+
+            /// <summary>
+            /// The configuration key for providing the Maximum Days Cache value via the web.config
+            /// </summary>
+            public const string MaxDaysKey = "AzureBlobFileSystem.MaxDays";
         }
     }
 }

--- a/src/UmbracoFileSystemProviders.Azure/Constants.cs
+++ b/src/UmbracoFileSystemProviders.Azure/Constants.cs
@@ -26,11 +26,6 @@ namespace Our.Umbraco.FileSystemProviders.Azure
             public const string DisableVirtualPathProviderKey = "AzureBlobFileSystem.DisableVirtualPathProvider";
 
             /// <summary>
-            /// The configuration key for enabling the storage emulator.
-            /// </summary>
-            public const string UseStorageEmulatorKey = "AzureBlobFileSystem.UseStorageEmulator";
-
-            /// <summary>
             /// The configuration key for providing the connection string via the web.config
             /// </summary>
             public const string ConnectionStringKey = "AzureBlobFileSystem.ConnectionString";
@@ -39,11 +34,6 @@ namespace Our.Umbraco.FileSystemProviders.Azure
             /// The configuration key for providing the Azure Blob Container Name via the web.config
             /// </summary>
             public const string ContainerNameKey = "AzureBlobFileSystem.ContainerName";
-
-            /// <summary>
-            /// The configuration key for providing the Storage Root URL via the web.config
-            /// </summary>
-            public const string RootUrlKey = "AzureBlobFileSystem.RootUrl";
 
             /// <summary>
             /// The configuration key for providing the Maximum Days Cache value via the web.config


### PR DESCRIPTION
Hi,

I was working on making the provider use the app settings, so you can use it in an azure website and you don't need the config in your code. **cyberprune** was also working on this and already requested a pull request, that you approved today :) But I think I have some additional changes/simplifications that could be nice to have. This is what I've done... (all tests are passing and the branch is up to date with the latest develop branch).

I've removed the following app settings and config parameters:
- AzureBlobFileSystem.UseStorageEmulator
- rootUrl

The `AzureBlobFileSystem.UseStorageEmulator` could be removed since you can get that information from the connectionstring. If it is `UseDevelopmentStorage=true` then the emulator should be used.
The `rootUrl` parameter is not needed since you can get the blob url from the container `this.cloudBlobContainer.StorageUri.PrimaryUri.AbsoluteUri`.

I also updated the `README.md`.
