### PR TITLE
Path FixUp & SubDirectories

### DIFF
--- a/src/UmbracoFileSystemProviders.Azure.Tests/AzureBlobFileSystemTestsBase.cs
+++ b/src/UmbracoFileSystemProviders.Azure.Tests/AzureBlobFileSystemTestsBase.cs
@@ -294,7 +294,7 @@ namespace Our.Umbraco.FileSystemProviders.Azure.Tests
             IEnumerable<string> actual = provider.GetDirectories("/");
 
             // Assert
-            string[] expected = { "1010/", "1011/", "1012/", "forms/", "testvalid/" };
+            string[] expected = { "1010/", "1011/", "1012/" };
             Assert.IsTrue(expected.SequenceEqual(actual));
         }
 
@@ -315,7 +315,7 @@ namespace Our.Umbraco.FileSystemProviders.Azure.Tests
             IEnumerable<string> actual = provider.GetDirectories("/");
 
             // Assert
-            string[] expected = { "1010/", "1011/", "1012/", "testvalid/" };
+            string[] expected = { "1010/", "1011/", "1012/" };
             Assert.IsTrue(expected.SequenceEqual(actual));
         }
         
@@ -533,6 +533,9 @@ namespace Our.Umbraco.FileSystemProviders.Azure.Tests
             // Assert
             string[] expected = { "forms/form_123/", "forms/form_456/" };
             Assert.IsTrue(expected.SequenceEqual(actual));
+
+            // Tidy up after test
+            provider.DeleteDirectory("forms");
         }
 
         /// <summary>
@@ -559,10 +562,11 @@ namespace Our.Umbraco.FileSystemProviders.Azure.Tests
             }
 
             // Assert
-            string[] expected = { "forms/form_123/kitty.jpg", "forms/form_123/dog.jpg", "forms/form_456/panda.jpg" };
+            string[] expected = { "forms/form_123/dog.jpg", "forms/form_123/kitty.jpg", "forms/form_456/panda.jpg" };
             Assert.IsTrue(expected.SequenceEqual(actual));
-        }
-        
 
+            // Tidy up after test
+            provider.DeleteDirectory("forms");
+        }
     }
 }

--- a/src/UmbracoFileSystemProviders.Azure.Tests/AzureBlobFileSystemTestsBase.cs
+++ b/src/UmbracoFileSystemProviders.Azure.Tests/AzureBlobFileSystemTestsBase.cs
@@ -455,6 +455,21 @@ namespace Our.Umbraco.FileSystemProviders.Azure.Tests
             Assert.IsFalse(provider.FileExists("1010/media.jpg"));
         }
 
+        [Test]
+        public void TestValidDirectory()
+        {
+            AzureBlobFileSystem provider = this.CreateAzureBlobFileSystem();
+            provider.AddFile("testvalid/test.txt", Stream.Null);
+            Assert.IsTrue(provider.DirectoryExists("testvalid"));
+        }
+
+        [Test]
+        public void TestInvalidDirectory()
+        {
+            AzureBlobFileSystem provider = this.CreateAzureBlobFileSystem();
+            Assert.IsFalse(provider.DirectoryExists("testinvalid/"));
+        }
+
         /// <summary>
         /// Asserts that the file system correctly deletes a directory when the input has been prefixed.
         /// </summary>

--- a/src/UmbracoFileSystemProviders.Azure.Tests/AzureBlobFileSystemTestsBase.cs
+++ b/src/UmbracoFileSystemProviders.Azure.Tests/AzureBlobFileSystemTestsBase.cs
@@ -294,7 +294,7 @@ namespace Our.Umbraco.FileSystemProviders.Azure.Tests
             IEnumerable<string> actual = provider.GetDirectories("/");
 
             // Assert
-            string[] expected = { "1010/", "1011/", "1012/" };
+            string[] expected = { "1010", "1011", "1012" };
             Assert.IsTrue(expected.SequenceEqual(actual));
         }
 
@@ -315,7 +315,7 @@ namespace Our.Umbraco.FileSystemProviders.Azure.Tests
             IEnumerable<string> actual = provider.GetDirectories("/");
 
             // Assert
-            string[] expected = { "1010/", "1011/", "1012/" };
+            string[] expected = { "1010", "1011", "1012" };
             Assert.IsTrue(expected.SequenceEqual(actual));
         }
         
@@ -534,7 +534,7 @@ namespace Our.Umbraco.FileSystemProviders.Azure.Tests
             IEnumerable<string> actual = provider.GetDirectories("forms");
 
             // Assert
-            string[] expected = { "forms/form_123/", "forms/form_456/" };
+            string[] expected = { "forms/form_123", "forms/form_456" };
             Assert.IsTrue(expected.SequenceEqual(actual));
 
             // Tidy up after test

--- a/src/UmbracoFileSystemProviders.Azure.Tests/AzureBlobFileSystemTestsBase.cs
+++ b/src/UmbracoFileSystemProviders.Azure.Tests/AzureBlobFileSystemTestsBase.cs
@@ -461,6 +461,9 @@ namespace Our.Umbraco.FileSystemProviders.Azure.Tests
             AzureBlobFileSystem provider = this.CreateAzureBlobFileSystem();
             provider.AddFile("testvalid/test.txt", Stream.Null);
             Assert.IsTrue(provider.DirectoryExists("testvalid"));
+
+            // Tidy up after test
+            provider.DeleteDirectory("testvalid");
         }
 
         [Test]

--- a/src/UmbracoFileSystemProviders.Azure.Tests/AzureBlobFileSystemTestsBase.cs
+++ b/src/UmbracoFileSystemProviders.Azure.Tests/AzureBlobFileSystemTestsBase.cs
@@ -294,7 +294,7 @@ namespace Our.Umbraco.FileSystemProviders.Azure.Tests
             IEnumerable<string> actual = provider.GetDirectories("/");
 
             // Assert
-            string[] expected = { "1010", "1011", "1012" };
+            string[] expected = { "1010/", "1011/", "1012/", "forms/", "testvalid/" };
             Assert.IsTrue(expected.SequenceEqual(actual));
         }
 
@@ -315,10 +315,10 @@ namespace Our.Umbraco.FileSystemProviders.Azure.Tests
             IEnumerable<string> actual = provider.GetDirectories("/");
 
             // Assert
-            string[] expected = { "1010", "1011", "1012" };
+            string[] expected = { "1010/", "1011/", "1012/", "testvalid/" };
             Assert.IsTrue(expected.SequenceEqual(actual));
         }
-
+        
         /// <summary>
         /// Asserts that the file system correctly returns a sequence of files from the root
         /// container in the correct format.
@@ -513,5 +513,56 @@ namespace Our.Umbraco.FileSystemProviders.Azure.Tests
             Assert.IsFalse(provider.DirectoryExists("media/1010/"));
             Assert.IsFalse(provider.FileExists("media/1010/media.jpg"));
         }
+
+        /// <summary>
+        /// Asserts that the file system correctly returns a sequence of sub-directories in the
+        /// correct format.
+        /// </summary>
+        [Test]
+        public void TestGetSubDirectories()
+        {
+            // Arrange
+            AzureBlobFileSystem provider = this.CreateAzureBlobFileSystem();
+            provider.AddFile("forms/form_123/kitty.jpg", Stream.Null);
+            provider.AddFile("forms/form_123/dog.jpg", Stream.Null);
+            provider.AddFile("forms/form_456/panda.jpg", Stream.Null);
+
+            // Act
+            IEnumerable<string> actual = provider.GetDirectories("forms");
+
+            // Assert
+            string[] expected = { "forms/form_123/", "forms/form_456/" };
+            Assert.IsTrue(expected.SequenceEqual(actual));
+        }
+
+        /// <summary>
+        /// Asserts that the file system correctly returns a sequence of sub-directories in the
+        /// correct format.
+        /// </summary>
+        [Test]
+        public void TestGetSubDirectoriesAndFiles()
+        {
+            // Arrange
+            AzureBlobFileSystem provider = this.CreateAzureBlobFileSystem();
+            provider.AddFile("forms/form_123/kitty.jpg", Stream.Null);
+            provider.AddFile("forms/form_123/dog.jpg", Stream.Null);
+            provider.AddFile("forms/form_456/panda.jpg", Stream.Null);
+
+            // Act
+            var subfolders = provider.GetDirectories("forms");
+            var actual = new List<string>();
+
+            foreach (var folder in subfolders)
+            {
+                // Get files in subfolder and add to a single collection
+                actual.AddRange(provider.GetFiles(folder));
+            }
+
+            // Assert
+            string[] expected = { "forms/form_123/kitty.jpg", "forms/form_123/dog.jpg", "forms/form_456/panda.jpg" };
+            Assert.IsTrue(expected.SequenceEqual(actual));
+        }
+        
+
     }
 }

--- a/src/UmbracoFileSystemProviders.Azure/AzureFileSystem.cs
+++ b/src/UmbracoFileSystemProviders.Azure/AzureFileSystem.cs
@@ -407,7 +407,7 @@ namespace Our.Umbraco.FileSystemProviders.Azure
             IEnumerable<IListBlobItem> blobs = directory.ListBlobs().Where(blob => blob is CloudBlobDirectory).ToList();
 
             // Always get last segment for media sub folder simulation. E.g 1001, 1002
-            return blobs.Cast<CloudBlobDirectory>().Select(cd => cd.Prefix);
+            return blobs.Cast<CloudBlobDirectory>().Select(cd => cd.Prefix.TrimEnd('/'));
         }
 
         /// <summary>

--- a/src/UmbracoFileSystemProviders.Azure/AzureFileSystem.cs
+++ b/src/UmbracoFileSystemProviders.Azure/AzureFileSystem.cs
@@ -388,12 +388,10 @@ namespace Our.Umbraco.FileSystemProviders.Azure
         {
             CloudBlobDirectory directory = this.GetDirectoryReference(path);
 
-            IEnumerable<IListBlobItem> blobs = directory.ListBlobs().Where(blob => blob is CloudBlobDirectory);
+            IEnumerable<IListBlobItem> blobs = directory.ListBlobs().Where(blob => blob is CloudBlobDirectory).ToList();
 
             // Always get last segment for media sub folder simulation. E.g 1001, 1002
-            return blobs.Select(cd =>
-                                cd.Uri.Segments[cd.Uri.Segments.Length - 1].Split(Delimiter.ToCharArray())[0]);
-
+            return blobs.Cast<CloudBlobDirectory>().Select(cd => cd.Prefix);
         }
 
         /// <summary>


### PR DESCRIPTION
## Changes
`GetDirectories()` now returns a path than just the foldername. More inline with Umbraco Core Physcial Media File Provider. Which allows sub directories to be stored & used with GetFiles without prefixing the path. See `TestGetSubDirectoriesAndFiles()` for this.

`DeleteDirectory()` now supports if the path contains subfolders as the previous selection was only grabbing files inside a folder, this can be verified with the `forms` folder cleanup in the tests.

## Tests
I have all tests passing and ensured a couple of tests delete/tidy up after themselves so when we loop back around over the same tests leftover folders don't exist & thus fail further tests. 