### PR TITLE
Private blob container option

### DIFF
--- a/build/transforms/FileSystemProviders.config.install.xdt
+++ b/build/transforms/FileSystemProviders.config.install.xdt
@@ -22,6 +22,10 @@
         of the container name.
       -->
       <add key="useDefaultRoute" value="true" xdt:Locator="Match(key)" xdt:Transform="InsertIfMissing" />
+      <!--
+        When true blob containers will be private instead of public what means that you can't access the original blob file directly from its blob url.
+      -->
+      <add key="usePrivateContainer" value="false" xdt:Locator="Match(key)" xdt:Transform="InsertIfMissing" />
     </Parameters>
   </Provider>
   <!--

--- a/src/.nuget/packages.config
+++ b/src/.nuget/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="StyleCop.Analyzers" version="1.0.0" />
+</packages>

--- a/src/UmbracoFileSystemProviders.Azure.Installer/Configurator/Controllers/Configure.js
+++ b/src/UmbracoFileSystemProviders.Azure.Installer/Configurator/Controllers/Configure.js
@@ -38,6 +38,6 @@ configApp.controller("Loader", function ($scope, $http, $log) {
     };
 
     $scope.getInputType = function (param) {
-        return param.toUpperCase() === "USEDEFAULTROUTE" ? "checkbox" : "text";
+        return param.toUpperCase() === "USEDEFAULTROUTE" || param.toUpperCase() === "USEPRIVATECONTAINER" ? "checkbox" : "text";
     };
 });

--- a/src/UmbracoFileSystemProviders.Azure.Installer/InstallerController.cs
+++ b/src/UmbracoFileSystemProviders.Azure.Installer/InstallerController.cs
@@ -77,6 +77,7 @@ namespace Our.Umbraco.FileSystemProviders.Azure.Installer
             string connection = newParameters.SingleOrDefault(k => k.Key == "connectionString").Value;
             string containerName = newParameters.SingleOrDefault(k => k.Key == "containerName").Value;
             bool useDefaultRoute = bool.Parse(newParameters.SingleOrDefault(k => k.Key == "useDefaultRoute").Value);
+            bool usePrivateContainer = bool.Parse(newParameters.SingleOrDefault(k => k.Key == "usePrivateContainer").Value);
             string rootUrl = newParameters.SingleOrDefault(k => k.Key == "rootUrl").Value;
 
             if (!TestAzureCredentials(connection, containerName))

--- a/src/UmbracoFileSystemProviders.Azure.Tests/AzureBlobFileSystemTestsBase.cs
+++ b/src/UmbracoFileSystemProviders.Azure.Tests/AzureBlobFileSystemTestsBase.cs
@@ -42,11 +42,12 @@ namespace Our.Umbraco.FileSystemProviders.Azure.Tests
             string connectionString = "UseDevelopmentStorage=true";
             string maxDays = "30";
             string useDefaultRoute = "true";
+            string usePrivateContainer = "false";
 
             Mock<ILogHelper> logHelper = new Mock<ILogHelper>();
             Mock<IMimeTypeResolver> mimeTypeHelper = new Mock<IMimeTypeResolver>();
 
-            return new AzureBlobFileSystem(containerName, rootUrl, connectionString, maxDays, useDefaultRoute)
+            return new AzureBlobFileSystem(containerName, rootUrl, connectionString, maxDays, useDefaultRoute, usePrivateContainer)
             {
                 FileSystem =
                 {

--- a/src/UmbracoFileSystemProviders.Azure.Tests/InstallerTests.cs
+++ b/src/UmbracoFileSystemProviders.Azure.Tests/InstallerTests.cs
@@ -25,7 +25,7 @@ namespace Our.Umbraco.FileSystemProviders.Azure.Tests
         public void CheckXdtNumberOfParameters()
         {
             var parameters = InstallerController.GetParametersFromXml("..\\..\\build\\transforms\\FileSystemProviders.config.install.xdt");
-            Assert.AreEqual(5, parameters.Count());
+            Assert.AreEqual(6, parameters.Count());
         }
 
         [Test]

--- a/src/UmbracoFileSystemProviders.Azure/AzureBlobFileSystem.cs
+++ b/src/UmbracoFileSystemProviders.Azure/AzureBlobFileSystem.cs
@@ -45,6 +45,11 @@ namespace Our.Umbraco.FileSystemProviders.Azure
         private const string UseDefaultRootKey = Constants.Configuration.UseDefaultRouteKey;
 
         /// <summary>
+        /// The configuration key for determining whether the container should be private.
+        /// </summary>
+        private const string UsePrivateContainerKey = Constants.Configuration.UsePrivateContainer;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="AzureBlobFileSystem"/> class.
         /// </summary>
         /// <param name="containerName">The container name.</param>
@@ -115,11 +120,13 @@ namespace Our.Umbraco.FileSystemProviders.Azure
                     useDefaultRoute = "true";
                 }
 
-                string accessType = ConfigurationManager.AppSettings[$"{UseDefaultRootKey}:{alias}"];
-                if (string.IsNullOrWhiteSpace(useDefaultRoute))
+                string accessType = ConfigurationManager.AppSettings[$"{UsePrivateContainerKey}:{alias}"];
+                if (string.IsNullOrWhiteSpace(accessType))
                 {
-                    useDefaultRoute = "true";
+                    accessType = "true";
                 }
+
+                this.FileSystem = AzureFileSystem.GetInstance(containerName, rootUrl, connectionString, maxDays, useDefaultRoute, accessType);
 
 
                 this.FileSystem = AzureFileSystem.GetInstance(containerName, rootUrl, connectionString, maxDays, useDefaultRoute,accessType);

--- a/src/UmbracoFileSystemProviders.Azure/AzureBlobFileSystem.cs
+++ b/src/UmbracoFileSystemProviders.Azure/AzureBlobFileSystem.cs
@@ -3,6 +3,8 @@
 // Licensed under the Apache License, Version 2.0.
 // </copyright>
 
+using Microsoft.WindowsAzure.Storage.Blob;
+
 namespace Our.Umbraco.FileSystemProviders.Azure
 {
     using System;
@@ -49,7 +51,7 @@ namespace Our.Umbraco.FileSystemProviders.Azure
         /// <param name="rootUrl">The root url.</param>
         /// <param name="connectionString">The connection string.</param>
         public AzureBlobFileSystem(string containerName, string rootUrl, string connectionString)
-            : this(containerName, rootUrl, connectionString, "365", "true")
+            : this(containerName, rootUrl, connectionString, "365", "true", "false")
         {
         }
 
@@ -61,9 +63,22 @@ namespace Our.Umbraco.FileSystemProviders.Azure
         /// <param name="connectionString">The connection string.</param>
         /// <param name="maxDays">The maximum number of days to cache blob items for in the browser.</param>
         /// <param name="useDefaultRoute">Whether to use the default "media" route in the url independent of the blob container.</param>
-        public AzureBlobFileSystem(string containerName, string rootUrl, string connectionString, string maxDays, string useDefaultRoute)
+        public AzureBlobFileSystem(string containerName, string rootUrl, string connectionString, string maxDays, string useDefaultRoute): this(containerName, rootUrl, connectionString, maxDays, useDefaultRoute, "false")
         {
-            this.FileSystem = AzureFileSystem.GetInstance(containerName, rootUrl, connectionString, maxDays, useDefaultRoute);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AzureBlobFileSystem"/> class.
+        /// </summary>
+        /// <param name="containerName">The container name.</param>
+        /// <param name="rootUrl">The root url.</param>
+        /// <param name="connectionString">The connection string.</param>
+        /// <param name="maxDays">The maximum number of days to cache blob items for in the browser.</param>
+        /// <param name="useDefaultRoute">Whether to use the default "media" route in the url independent of the blob container.</param>
+        /// <param name="usePrivateContainer">blob container can be private (no direct access) or public (direct access possible, default)</param>
+        public AzureBlobFileSystem(string containerName, string rootUrl, string connectionString, string maxDays, string useDefaultRoute, string usePrivateContainer)
+        {
+            this.FileSystem = AzureFileSystem.GetInstance(containerName, rootUrl, connectionString, maxDays, useDefaultRoute, usePrivateContainer);
         }
 
         /// <summary>
@@ -100,7 +115,14 @@ namespace Our.Umbraco.FileSystemProviders.Azure
                     useDefaultRoute = "true";
                 }
 
-                this.FileSystem = AzureFileSystem.GetInstance(containerName, rootUrl, connectionString, maxDays, useDefaultRoute);
+                string accessType = ConfigurationManager.AppSettings[$"{UseDefaultRootKey}:{alias}"];
+                if (string.IsNullOrWhiteSpace(useDefaultRoute))
+                {
+                    useDefaultRoute = "true";
+                }
+
+
+                this.FileSystem = AzureFileSystem.GetInstance(containerName, rootUrl, connectionString, maxDays, useDefaultRoute,accessType);
             }
             else
             {

--- a/src/UmbracoFileSystemProviders.Azure/Constants.cs
+++ b/src/UmbracoFileSystemProviders.Azure/Constants.cs
@@ -54,6 +54,11 @@ namespace Our.Umbraco.FileSystemProviders.Azure
             /// The configuration key for providing the Use Default Root value via the web.config
             /// </summary>
             public const string UseDefaultRouteKey = "AzureBlobFileSystem.UseDefaultRoute";
+
+            /// <summary>
+            /// The configuration key for providing the Use Private Container value via the web.config
+            /// </summary>
+            public const string UsePrivateContainer = "AzureBlobFileSystem.UsePrivateContainer";
         }
     }
 }


### PR DESCRIPTION
Added a  configuration option (checkbox) that allows users to select private container during install. When selected the blob container is created as a private container and files cannot be viewed directly via the blob url.

The normal Umbraco media Url for the virtual path provider will still work since the request to azure will be made using an authenticated connection.