### PR TITLE
Fixing bug when Umbraco is hosted in Virtual Path instead of root

### DIFF
--- a/src/UmbracoFileSystemProviders.Azure.Tests/AzureBlobFileSystemTestsBase.cs
+++ b/src/UmbracoFileSystemProviders.Azure.Tests/AzureBlobFileSystemTestsBase.cs
@@ -24,10 +24,11 @@ namespace Our.Umbraco.FileSystemProviders.Azure.Tests
         /// Creates an instance of <see cref="AzureBlobFileSystem"/> set up for developmental testing.
         /// </summary>
         /// <param name="disableVirtualPathProvider">Whether to disable the virtual path provider.</param>
+        /// <param name="appVirtualPath">Mocked virtual path of application</param>
         /// <returns>
         /// The <see cref="AzureBlobFileSystem"/>.
         /// </returns>
-        public AzureBlobFileSystem CreateAzureBlobFileSystem(bool disableVirtualPathProvider = false)
+        public AzureBlobFileSystem CreateAzureBlobFileSystem(bool disableVirtualPathProvider = false, string appVirtualPath = "")
         {
             string containerName = "media";
             string rootUrl = "http://127.0.0.1:10000/devstoreaccount1/";
@@ -45,7 +46,8 @@ namespace Our.Umbraco.FileSystemProviders.Azure.Tests
                 {
                     LogHelper = logHelper.Object,
                     MimeTypeResolver = mimeTypeHelper.Object,
-                    DisableVirtualPathProvider = disableVirtualPathProvider
+                    DisableVirtualPathProvider = disableVirtualPathProvider,
+                    ApplicationVirtualPath = appVirtualPath
                 }
             };
         }
@@ -97,6 +99,23 @@ namespace Our.Umbraco.FileSystemProviders.Azure.Tests
 
             // Assert
             Assert.AreEqual("/media/1010/media.jpg", actual);
+        }
+
+
+        /// <summary>
+        /// Asserts that the file system correctly resolves the relative path when Umbraco is hosted in virtual path
+        /// </summary>
+        [Test]
+        public void ResolveRelativePathWithAppVirtualPath()
+        {
+            // Arrange
+            AzureBlobFileSystem provider = this.CreateAzureBlobFileSystem(false, "/test");
+
+            // Act
+            string actual = provider.GetRelativePath("1010/media.jpg");
+
+            // Assert
+            Assert.AreEqual("/test/media/1010/media.jpg", actual);
         }
 
         /// <summary>

--- a/src/UmbracoFileSystemProviders.Azure/AzureFileSystem.cs
+++ b/src/UmbracoFileSystemProviders.Azure/AzureFileSystem.cs
@@ -15,6 +15,7 @@ namespace Our.Umbraco.FileSystemProviders.Azure
     using System.IO;
     using System.Linq;
     using System.Text.RegularExpressions;
+    using System.Web;
     using global::Umbraco.Core.IO;
     using Microsoft.WindowsAzure.Storage;
     using Microsoft.WindowsAzure.Storage.Blob;
@@ -158,6 +159,12 @@ namespace Our.Umbraco.FileSystemProviders.Azure
         /// independent of the blob container.
         /// </summary>
         public bool UseDefaultRoute { get; }
+
+        /// <summary>
+        /// Gets or sets func to calculate application virtual path
+        /// </summary>
+        public string ApplicationVirtualPath { get; internal set; } = HttpRuntime.AppDomainAppVirtualPath;
+
 
         /// <summary>
         /// Returns a singleton instance of the <see cref="AzureFileSystem"/> class.
@@ -620,6 +627,8 @@ namespace Our.Umbraco.FileSystemProviders.Azure
         /// </returns>
         private string ResolveUrl(string path, bool relative)
         {
+            string appVirtualPath = this.ApplicationVirtualPath;
+
             // First create the full url
             string fixedPath = this.FixPath(path);
 
@@ -632,10 +641,10 @@ namespace Our.Umbraco.FileSystemProviders.Azure
 
             if (this.UseDefaultRoute)
             {
-                return $"/{Constants.DefaultMediaRoute}/{fixedPath}";
+                return $"{appVirtualPath}/{Constants.DefaultMediaRoute}/{fixedPath}";
             }
 
-            return $"/{this.ContainerName}/{fixedPath}";
+            return $"{appVirtualPath}/{this.ContainerName}/{fixedPath}";
         }
 
         /// <summary>
@@ -651,6 +660,12 @@ namespace Our.Umbraco.FileSystemProviders.Azure
             if (string.IsNullOrEmpty(path))
             {
                 return string.Empty;
+            }
+
+            string appVirtualPath = this.ApplicationVirtualPath;
+            if (path.StartsWith(appVirtualPath))
+            {
+                path = path.Substring(appVirtualPath.Length);
             }
 
             if (path.StartsWith(Delimiter))

--- a/src/UmbracoFileSystemProviders.Azure/FileSystemVirtualPathProvider.cs
+++ b/src/UmbracoFileSystemProviders.Azure/FileSystemVirtualPathProvider.cs
@@ -7,6 +7,7 @@ namespace Our.Umbraco.FileSystemProviders.Azure
 {
     using System;
     using System.Diagnostics.CodeAnalysis;
+    using System.Web;
     using System.Web.Hosting;
 
     using global::Umbraco.Core.IO;
@@ -152,7 +153,7 @@ namespace Our.Umbraco.FileSystemProviders.Azure
             prefix = prefix.Replace("\\", "/");
             prefix = prefix.StartsWith("/") ? prefix : string.Concat("/", prefix);
             prefix = prefix.EndsWith("/") ? prefix : string.Concat(prefix, "/");
-            return prefix;
+            return HttpRuntime.AppDomainAppVirtualPath + prefix;
         }
 
         /// <summary>


### PR DESCRIPTION
When Umbraco is hosted in a virtual path, your provider doesn't work. It is because all paths start with "/" instead of AppDomainAppVirtualPath.
I added fix for above + unit test. Moreover I upgraded NUnit for live unit testing support in VS 2017.

