### PR TITLE
Media files were being uploaded with paths that started //media

### DIFF
--- a/src/UmbracoFileSystemProviders.Azure/AzureFileSystem.cs
+++ b/src/UmbracoFileSystemProviders.Azure/AzureFileSystem.cs
@@ -665,10 +665,10 @@ namespace Our.Umbraco.FileSystemProviders.Azure
 
             if (this.UseDefaultRoute)
             {
-                return $"{this.ApplicationVirtualPath}/{Constants.DefaultMediaRoute}/{fixedPath}";
+                return $"{this.ApplicationVirtualPath?.Trim('/')}/{Constants.DefaultMediaRoute}/{fixedPath}";
             }
 
-            return $"{this.ApplicationVirtualPath}/{this.ContainerName}/{fixedPath}";
+            return $"{this.ApplicationVirtualPath?.Trim('/')}/{this.ContainerName}/{fixedPath}";
         }
 
         /// <summary>


### PR DESCRIPTION
My Umbraco install is in the root and I noticed media items displaying in the back office with //media at the beginning of the path.