### PR TITLE
Update to fix file path to remove ~ from media file path.

### DIFF
--- a/src/UmbracoFileSystemProviders.Azure/AzureFileSystem.cs
+++ b/src/UmbracoFileSystemProviders.Azure/AzureFileSystem.cs
@@ -702,6 +702,12 @@ namespace Our.Umbraco.FileSystemProviders.Azure
                 path = path.Substring(appVirtualPath.Length);
             }
 
+            // Strip ~  before any others
+            if (path.StartsWith("~", StringComparison.InvariantCultureIgnoreCase))
+            {
+                path = path.Substring(1);
+            }
+
             if (path.StartsWith(Delimiter))
             {
                 path = path.Substring(1);


### PR DESCRIPTION
Ran into an issue with Umbraco Forms 4.4.0 when using Azure Blob Storage where the media path started with ~/media.  The FixPath function does not take that situation into account and so the files were not being uploaded to the blob storage as expected.