### PR TITLE
Fixing issue with Media folder not being found in Umbraco > 7.5.14

### DIFF
--- a/src/UmbracoFileSystemProviders.Azure/AzureFileSystem.cs
+++ b/src/UmbracoFileSystemProviders.Azure/AzureFileSystem.cs
@@ -16,6 +16,7 @@ namespace Our.Umbraco.FileSystemProviders.Azure
     using System.Linq;
     using System.Text.RegularExpressions;
     using System.Web;
+    using global::Umbraco.Core.Configuration;
     using global::Umbraco.Core.IO;
     using Microsoft.WindowsAzure.Storage;
     using Microsoft.WindowsAzure.Storage.Blob;
@@ -540,8 +541,19 @@ namespace Our.Umbraco.FileSystemProviders.Azure
         /// <returns>
         /// The <see cref="string"/> representing the relative path.
         /// </returns>
+        /// <remarks>
+        /// Umbraco 7.5.15 changed the way that relative paths are used for media upload. 
+        /// This is the fixing issue where uploading file to replace creates new folder.
+        /// </remarks>
         public string GetRelativePath(string fullPathOrUrl)
         {
+            var lastSafeVersion = new Version(7, 5, 14);
+  
+            if (UmbracoVersion.Current.CompareTo(lastSafeVersion) > 0)
+            {
+                return this.FixPath(fullPathOrUrl);
+            }
+
             return this.ResolveUrl(fullPathOrUrl, true);
         }
 


### PR DESCRIPTION
Hi, Been having issues with updating files in Azure breaking links due to the folder number incrementing. This is as described here: 

https://our.umbraco.org/forum/using-umbraco-and-getting-started/89715-unwanted-change-of-link-to-media

Found at that since 7.5.15 that Umbraco is expecting relative URL's in format 1000/ex.pdf as opposed to the older style of /media/1000/ex.pdf. As a result when Umbraco it goes to upload the file, it can't parse the older style relative URL to find the folder number and just creates a new one. 

I've put in a version switch on the relative URL retrieval so that it will return the relative URL relevant to the Umbraco version. 

Fixed our issues with 7.7.7 and Azure.  

Cheers, 

Warwick