### PR TITLE
Enable async operation when uploading from stream

### DIFF
--- a/src/UmbracoFileSystemProviders.Azure/AzureFileSystem.cs
+++ b/src/UmbracoFileSystemProviders.Azure/AzureFileSystem.cs
@@ -293,7 +293,7 @@ namespace Our.Umbraco.FileSystemProviders.Azure
                         }
                     }
 
-                    blockBlob.UploadFromStream(stream);
+                    blockBlob.UploadFromStreamAsync(stream).ConfigureAwait(false).GetAwaiter().GetResult();
 
                     string contentType = this.MimeTypeResolver.Resolve(path);
 


### PR DESCRIPTION
When trying to upload a file 14MB+ is taking a lot of time to upload (nevers uploads in my case). Using the async variant fixes the issue.