### PR TITLE
Makes GetBlockBlobReference public just like v2

### DIFF
--- a/src/UmbracoFileSystemProviders.Azure/AzureFileSystem.cs
+++ b/src/UmbracoFileSystemProviders.Azure/AzureFileSystem.cs
@@ -809,7 +809,7 @@ namespace Our.Umbraco.FileSystemProviders.Azure
         /// <returns>
         /// The <see cref="BlobClient"/> reference.
         /// </returns>
-        private BlobClient GetBlockBlobReference(string path)
+        public BlobClient GetBlockBlobReference(string path)
         {
             Current.Logger.Debug<AzureBlobFileSystem>($"GetBlockBlobReference(path) method executed with path:{path}");
 


### PR DESCRIPTION
I previously made this method public in a PR that was merged though I don't know if that version ever got released (I'm still using reflection). This also makes this method public (perhaps v2 hasn't been merged to v3?)