### PR TITLE
404's when using ImageProcessor / other file systems

### DIFF
--- a/src/UmbracoFileSystemProviders.Azure/AzureFileSystem.cs
+++ b/src/UmbracoFileSystemProviders.Azure/AzureFileSystem.cs
@@ -814,14 +814,14 @@ namespace Our.Umbraco.FileSystemProviders.Azure
         {
             Current.Logger.Debug<AzureBlobFileSystem>($"GetBlockBlobReference(path) method executed with path:{path}");
 
-            string blobPath = this.FixPath(path);
-
             // Only make the request if there is an actual path. See issue 8.
             // https://github.com/JimBobSquarePants/UmbracoFileSystemProviders.Azure/issues/8
             if (string.IsNullOrWhiteSpace(path))
             {
                 return null;
             }
+
+            string blobPath = this.FixPath(path);
 
             try
             {

--- a/src/UmbracoFileSystemProviders.Azure/FileSystemVirtualFile.cs
+++ b/src/UmbracoFileSystemProviders.Azure/FileSystemVirtualFile.cs
@@ -9,7 +9,6 @@ namespace Our.Umbraco.FileSystemProviders.Azure
     using System.IO;
     using System.Web;
     using System.Web.Hosting;
-    using global::Umbraco.Core.Composing;
     using global::Umbraco.Core.IO;
 
     /// <summary>
@@ -17,6 +16,11 @@ namespace Our.Umbraco.FileSystemProviders.Azure
     /// </summary>
     internal class FileSystemVirtualFile : VirtualFile
     {
+        /// <summary>
+        /// The file system.
+        /// </summary>
+        private readonly IFileSystem fileSystem;
+
         /// <summary>
         /// The stream function delegate.
         /// </summary>
@@ -40,7 +44,9 @@ namespace Our.Umbraco.FileSystemProviders.Azure
                 throw new ArgumentNullException(nameof(fileSystem));
             }
 
-            this.stream = () => fileSystem.Value.OpenFile(fileSystemPath);
+            this.fileSystem = fileSystem.Value;
+
+            this.stream = () => this.fileSystem.OpenFile(fileSystemPath);
         }
 
         /// <summary>
@@ -69,14 +75,15 @@ namespace Our.Umbraco.FileSystemProviders.Azure
                 // Add Accept-Ranges header to fix videos not playing on Safari
                 HttpContext.Current.Response.AppendHeader("Accept-Ranges", "bytes");
 
-                IFileSystem azureBlobFileSystem = Current.MediaFileSystem.Unwrap();
-                int maxDays = ((AzureBlobFileSystem)azureBlobFileSystem).FileSystem.MaxDays;
+                var azureBlobFileSystem = (AzureBlobFileSystem)this.fileSystem;
 
+                int maxDays = azureBlobFileSystem.FileSystem.MaxDays;
                 cache.SetExpires(DateTime.Now.ToUniversalTime().AddDays(maxDays));
                 cache.SetMaxAge(new TimeSpan(maxDays, 0, 0, 0));
                 cache.SetRevalidation(HttpCacheRevalidation.AllCaches);
                 cache.SetLastModified(azureBlobFileSystem.GetLastModified(VirtualPath).DateTime);
-                var etag = ((AzureBlobFileSystem)azureBlobFileSystem).FileSystem.GetETag(VirtualPath);
+
+                var etag = azureBlobFileSystem.FileSystem.GetETag(VirtualPath);
                 if (!string.IsNullOrWhiteSpace(etag))
                 {
                     cache.SetETag(etag);

--- a/src/UmbracoFileSystemProviders.Azure/FileSystemVirtualFile.cs
+++ b/src/UmbracoFileSystemProviders.Azure/FileSystemVirtualFile.cs
@@ -75,15 +75,19 @@ namespace Our.Umbraco.FileSystemProviders.Azure
                 // Add Accept-Ranges header to fix videos not playing on Safari
                 HttpContext.Current.Response.AppendHeader("Accept-Ranges", "bytes");
 
-                var azureBlobFileSystem = (AzureBlobFileSystem)this.fileSystem;
+                var unwrappedFileSystem = this.fileSystem.Unwrap();
+                if (!(unwrappedFileSystem is AzureFileSystem azureFileSystem))
+                {
+                    azureFileSystem = ((AzureBlobFileSystem)this.fileSystem).FileSystem;
+                }
 
-                int maxDays = azureBlobFileSystem.FileSystem.MaxDays;
+                int maxDays = azureFileSystem.MaxDays;
                 cache.SetExpires(DateTime.Now.ToUniversalTime().AddDays(maxDays));
                 cache.SetMaxAge(new TimeSpan(maxDays, 0, 0, 0));
                 cache.SetRevalidation(HttpCacheRevalidation.AllCaches);
-                cache.SetLastModified(azureBlobFileSystem.GetLastModified(VirtualPath).DateTime);
+                cache.SetLastModified(azureFileSystem.GetLastModified(VirtualPath).DateTime);
 
-                var etag = azureBlobFileSystem.FileSystem.GetETag(VirtualPath);
+                var etag = azureFileSystem.GetETag(VirtualPath);
                 if (!string.IsNullOrWhiteSpace(etag))
                 {
                     cache.SetETag(etag);


### PR DESCRIPTION
As reported in #202, the recent v3 version doesn't play nicely when using ImageProcessor blob cache (or actually any file system that isn't the media file system).

It seems etag support was added in #179, which called some additional methods on the file system within the virtual file. If the blob does not exist `GetProperties` throws a "BlobNotFound" error.

Despite a file system being passed in to the constructor of the virtual file class, for a long time the code has been fetching the media file system out of Umbraco's service locator instead. As such, if the virtual file being requested doesn't exist in the media file system you get an error.