### PR TITLE
Adding public setter to AzureFileSystem.ApplicationVirtualPath

### DIFF
--- a/src/UmbracoFileSystemProviders.Azure/AzureFileSystem.cs
+++ b/src/UmbracoFileSystemProviders.Azure/AzureFileSystem.cs
@@ -212,7 +212,7 @@ namespace Our.Umbraco.FileSystemProviders.Azure
         /// <summary>
         /// Gets or sets func to calculate application virtual path
         /// </summary>
-        public string ApplicationVirtualPath { get; internal set; } = HttpRuntime.AppDomainAppVirtualPath;
+        public string ApplicationVirtualPath { get; set; } = HttpRuntime.AppDomainAppVirtualPath;
 
         public bool CanAddPhysical => false;
 


### PR DESCRIPTION
When using the `AzureBlobFileSystem` with custom configuration you may want to have the containers files mapped to a specific path. A custom path can be configured with the `FileSystemVirtualPathProvider`.

However this only works when the folder structure in the container matches the exact path, as the file system treats "/" as the default root path.

As the `ApplicationVirtualPath` property has an internal setter only it's not possible to change the default... Looking through the code + history I can't see any reason why this would be, or any harm that would be caused by making the setter public to support this scenario.

I've temporarily applied this via reflection in a project (🙃🤯) and it's working great:

```
var property = typeof(AzureFileSystem).GetProperty(nameof(AzureFileSystem.ApplicationVirtualPath));

var path = blobFileSystem.FileSystem.ApplicationVirtualPath + "...";

property.SetValue(blobFileSystem.FileSystem, path, null);
```